### PR TITLE
fix(frontend):  correct button import and remove accordion board

### DIFF
--- a/app/src/_codux/boards/accordion/accordion.board.tsx
+++ b/app/src/_codux/boards/accordion/accordion.board.tsx
@@ -1,8 +1,0 @@
-import { createBoard } from '@wixc3/react-board';
-import { Accordion } from '../../../components/ui/accordion';
-
-export default createBoard({
-    name: 'Accordion',
-    Board: () => <Accordion />,
-    isSnippet: true,
-});

--- a/app/src/_codux/boards/home.board.tsx
+++ b/app/src/_codux/boards/home.board.tsx
@@ -1,5 +1,5 @@
 import { createBoard } from "@wixc3/react-board";
-import Button from "../../components/";
+import { Button } from "../../components/ui/button";
 
 export default createBoard({
   name: "Home",


### PR DESCRIPTION
- correct Button import path in home.board.tsx
- remove redundant Accordion board (accordion is an external package, so no need for a board)

Closes #1 