### PR TITLE
[API] implement message actions: archive and delete messages

### DIFF
--- a/backend/controllers/message.controller.ts
+++ b/backend/controllers/message.controller.ts
@@ -94,6 +94,26 @@ class MessageController extends BaseController {
 		});
 	}
 
-	@Delete("/users/:id/messages/:msgId", isLoggedIn)
-	async removeMessage(req: Request, res: Response) {}
+	@Delete("/users/:id/messages/:messageId", isLoggedIn)
+	async removeMessage(req: GenericRequest<AuthUser>, res: Response) {
+		const { id, messageId } = req.params;
+
+		if (!isValidObjectId(id) || !isValidObjectId(messageId)) {
+			throw new CustomAPIError("The provided ID is invalid", 400);
+		}
+
+		if (id !== req.user.id) {
+			throw new CustomAPIError(
+				"You're not allowed to perform this action",
+				403,
+			);
+		}
+
+		const message = await MessageService.deleteMessage(id, messageId);
+
+		return res.status(200).json({
+			message: "successfully removed the message",
+			data: message,
+		});
+	}
 }

--- a/backend/services/message.service.ts
+++ b/backend/services/message.service.ts
@@ -108,6 +108,21 @@ class MessageService {
 			);
 		}
 	}
+
+	static async deleteMessage(ownerId: string, messageId: string) {
+		const message = await Message.findOneAndDelete({
+			_id: messageId,
+			owner: ownerId,
+		});
+
+		if (!message) {
+			throw new CustomAPIError(
+				"the provided ID is referring to a non-existing model",
+				404,
+			);
+		}
+		return message;
+	}
 }
 
 export default MessageService;


### PR DESCRIPTION
This PR implements two new routes:
 - **PATCH** - `/api/users/<user:id>/messages<message:id>?action`
   - action can only be `archive` or `unarchive`, and is required. (we likely don't want to assume guess your action for you)
 - **DELETE** - `/api/users/<user:id>/messages<message:id>`